### PR TITLE
Add the missing Ebi::call() method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
+dist: precise
+
 language: php
 
 php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - hhvm
 
 sudo: false
 
 matrix:
   allow_failures:
+    - php: 7.2
     - php: hhvm
   fast_finish: true
 

--- a/src/Ebi.php
+++ b/src/Ebi.php
@@ -165,6 +165,25 @@ class Ebi {
     }
 
     /**
+     * Call a function registered with **defineFunction()**.
+     *
+     * If a static or global function is registered then it's simply rendered in the compiled template.
+     * This method is for closures or callbacks.
+     *
+     * @param string $name The name of the registered function.
+     * @param array ...$args The function's argument.
+     * @return mixed Returns the result of the function
+     * @throws RuntimeException Throws an exception when the function isn't found.
+     */
+    public function call($name, ...$args) {
+        if (!isset($this->functions[$name])) {
+            throw new RuntimeException("Call to undefined function $name.", 500);
+        } else {
+            return $this->functions[$name](...$args);
+        }
+    }
+
+    /**
      * Load a component.
      *
      * @param string $component The name of the component to load.

--- a/src/RuntimeException.php
+++ b/src/RuntimeException.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @author Todd Burry <todd@vanillaforums.com>
+ * @copyright 2009-2017 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Ebi;
+
+class RuntimeException extends \Exception {
+
+}

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -18,4 +18,30 @@ class RuntimeTest extends AbstractTest {
 
         $this->assertEquals('bar', $ebi->render('test'));
     }
+
+    /**
+     * A closure that is added with **defineFunction** should be accessible with **call**.
+     */
+    public function testCallClosure() {
+        $ebi = new TestEbi($this);
+
+        $ebi->defineFunction('foo', function ($a, $b) {
+            return $a.$b.'!';
+        });
+
+        $v = $ebi->call('foo', 'bar', 'baz');
+        $this->assertEquals('barbaz!', $v);
+
+    }
+
+    /**
+     * A missing function should throw a **RuntimeException**.
+     *
+     * @expectedException \Ebi\RuntimeException
+     */
+    public function testCallMissingFunction() {
+        $ebi = new TestEbi($this);
+
+        $ebi->call('missing', 'foo');
+    }
 }


### PR DESCRIPTION
The call method is for functions that cannot be statically compiled
into a template.