### PR TITLE
Rename the "bi-" prefix to "x-"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: precise
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: trusty
 
 language: php
 

--- a/README.md
+++ b/README.md
@@ -70,12 +70,16 @@ All variables are HTML escaped by default. If you want to return unescaped HTML,
 
 ## Template Attributes
 
-### bi-if
+Most of Ebi's functionality is accessed using template attributes. These are HTML style attributes that you add to any tag in your template to add logic. All of Ebi's attributes start with an `x-` prefix to help you differentiate between Ebi attributes and regular HTML attributes.
+
+*The letter "X" was chosen to mean "extended attribute" and was inspired by the same prefix in HTTP headers.*
+
+### x-if
 
 Only display an element if the condition is true.
 
 ```html
-<p bi-if="empty(items)">
+<p x-if="empty(items)">
 There are no items!
 </p>
 ```
@@ -86,15 +90,15 @@ if (empty($data['items'])) {
 }
 ```
 
-### bi-else
+### x-else
 
 Add an else element in conjunction with an if element.
 
 ```html
-<div bi-if="signedIn">
+<div x-if="signedIn">
     Welcome!
 </div>
-<div bi-else>
+<div x-else>
     Sign in to participate.
 </div>
 ```
@@ -107,12 +111,12 @@ if ($data['signedIn']) {
 }
 ```
 
-### bi-each
+### x-each
 
 Loop over elements.
 
 ```html
-<ul bi-each="people">
+<ul x-each="people">
     <li>Hi {first} {last}!</li>
 </ul>
 ```
@@ -128,12 +132,12 @@ foreach ($data['people'] as $data1) {
 echo '</ul>';
 ```
 
-### bi-as
+### x-as
 
 Name the iterator element so that you can still reference the parent.
 
 ```html
-<ul bi-each="comments" bi-as="i comment">
+<ul x-each="comments" x-as="i comment">
     <li>{name}: {comment.body} #{i}</li>
 </ul>
 ```
@@ -152,16 +156,16 @@ foreach ($conext['comments'] as $i1 => $data1) {
 echo '</ul>';
 ```
 
-*Tip: If you want to access the key of an array, but still want to access its values without dot syntax then you can use `bi-as="key this"`.*
+*Tip: If you want to access the key of an array, but still want to access its values without dot syntax then you can use `x-as="key this"`.*
 
-### bi-empty
+### x-empty
 
 Specify a template when there are no items.
 
 ```html
-<ul bi-each="messages">
+<ul x-each="messages">
     <li>{body}</li>
-    <li bi-empty>There are no messages.</li>
+    <li x-empty>There are no messages.</li>
 </ul>
 ```
 
@@ -179,12 +183,12 @@ if (empty($data['messages'])) {
 echo '</ul>';
 ```
 
-### bi-with
+### x-with
 
 Pass an item into a template.
 
 ```html
-<div bi-with="user">
+<div x-with="user">
     Hello {name}.
 </div>
 ```
@@ -197,16 +201,16 @@ echo '<div>',
     '</div>';
 ```
 
-### bi-literal
+### x-literal
 
 Don't parse templates within a literal.
 
 ```html
-<code bi-literal>Hello <b bi-literal>{username}</b></code>
+<code x-literal>Hello <b x-literal>{username}</b></code>
 ```
 
 ```php
-echo '<code>Hello <b bi-literal>{username}</b></code>';
+echo '<code>Hello <b x-literal>{username}</b></code>';
 ```
 
 ### The "x" Tag
@@ -214,7 +218,7 @@ echo '<code>Hello <b bi-literal>{username}</b></code>';
 Sometimes you will want to use an ebi attribute, but don't want to render an HTML tag. In this case you can use the `x` tag which will only render its contents.
 
 ```html
-<x bi-if="signedIn">Welcome back</x>
+<x x-if="signedIn">Welcome back</x>
 ```
 
 ```php
@@ -230,14 +234,14 @@ Components are a powerful part of Ebi. With components you can make re-usable te
 - Each template is a component. You can declare additional components in a template too.
 - Components are lowercase. It is recommended that you use dashes to separate words in component names. Make sure to name your template files in lowercase to avoid issues with case sensitive file systems.
 - Components are used by declaring an HTML element with the component's name. Components create custom tags!
-- You can pass data into components with contributes. If you want to pass all of the current template's data into a component use the `bi-with` attribute.
+- You can pass data into components with contributes. If you want to pass all of the current template's data into a component use the `x-with` attribute.
 
-### bi-component
+### x-component
 
 Define a component that can be used later in the template.
 
 ```html
-<time bi-component="long-date" datetime="{date(date, 'c')}">{date(date, 'r')}</time>
+<time x-component="long-date" datetime="{date(date, 'c')}">{date(date, 'r')}</time>
 
 <long-date date="{dateInserted}" />
 ```
@@ -260,38 +264,38 @@ Components must begin with a capital letter or include a dash or dot. Otherwise 
 
 By default, components inherit the current scope's data. There are a few more things you can do to pass additional data into a component.
 
-#### Pass Data Using `bi-with`???
+#### Pass Data Using `x-with`???
 
-If you want to pass data other than the current context into a component you use the `bi-with` attribute.
+If you want to pass data other than the current context into a component you use the `x-with` attribute.
 
 ```html
-<div class="post post-commment" bi-component="Comment">
+<div class="post post-commment" x-component="Comment">
   <img src="{author.photoUrl}" /> <a href="author.url">{author.username}</a>
 
   <p>{unescape(body)}</p>
 </div>
 
-<Comment bi-with="lastComment" />
+<Comment x-with="lastComment" />
 ```
 
-### bi-child and bi-block
+### x-child and x-block
 
 You can define custom content elements within a component with blocks. An unnamed block will uses the same tag it's declared in. If you name a block then the name becomes its tag name.
 
 ```html
 <!-- Declare the layout component. -->
-<html bi-component="layout">
-  <head><title bi-child="title" /></head>
+<html x-component="layout">
+  <head><title x-child="title" /></head>
   <body>
-    <h1 bi-child="title" />
-    <div class="content" bi-child="content" />
+    <h1 x-child="title" />
+    <div class="content" x-child="content" />
   </body>
 </html>
 
 <!-- Use the layout component. -->
 <layout>
-  <x bi-block="title">Hello world!</x>
-  <p bi-block="content">When you put yourself out there you will always do well.</p>
+  <x x-block="title">Hello world!</x>
+  <p x-block="content">When you put yourself out there you will always do well.</p>
 </layout>
 ```
 
@@ -307,15 +311,15 @@ The blocks get inserted into the component when it is used.
 </html>
 ```
 
-### bi-include
+### x-include
 
-Sometimes you want to include a component dynamically. In this case you can use the `bi-include` attribute.
+Sometimes you want to include a component dynamically. In this case you can use the `x-include` attribute.
 
 ```html
-<div bi-component="hello">Hello {name}</div>
-<div bi-component="goodbye">Goodbye {name}</div>
+<div x-component="hello">Hello {name}</div>
+<div x-component="goodbye">Goodbye {name}</div>
 
-<x bi-include=""
+<x x-include=""
 ```
 
 ## HTML Utilities

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -12,18 +12,18 @@ use DOMElement;
 use DOMNode;
 
 class Compiler {
-    const T_IF = 'bi-if';
-    const T_EACH = 'bi-each';
-    const T_WITH = 'bi-with';
-    const T_LITERAL = 'bi-literal';
-    const T_AS = 'bi-as';
-    const T_COMPONENT = 'bi-component';
-    const T_CHILDREN = 'bi-children';
-    const T_BLOCK = 'bi-block';
-    const T_ELSE = 'bi-else';
-    const T_EMPTY = 'bi-empty';
+    const T_IF = 'x-if';
+    const T_EACH = 'x-each';
+    const T_WITH = 'x-with';
+    const T_LITERAL = 'x-literal';
+    const T_AS = 'x-as';
+    const T_COMPONENT = 'x-component';
+    const T_CHILDREN = 'x-children';
+    const T_BLOCK = 'x-block';
+    const T_ELSE = 'x-else';
+    const T_EMPTY = 'x-empty';
     const T_X = 'x';
-    const T_INCLUDE = 'bi-include';
+    const T_INCLUDE = 'x-include';
 
     protected static $special = [
         self::T_COMPONENT => 1,
@@ -899,7 +899,7 @@ class Compiler {
     /**
      * Find a special node in relation to another node.
      *
-     * This method is used to find things such as bi-empty and bi-else elements.
+     * This method is used to find things such as x-empty and x-else elements.
      *
      * @param DOMElement $node The node to search in relation to.
      * @param string $attribute The name of the attribute to search for.

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -44,7 +44,7 @@ abstract class AbstractTest extends TestCase {
     }
 
     public function doTest($name, $template, $data, $expected) {
-//        if ($name !== '02-components bi-children nested') {
+//        if ($name !== '02-components x-children nested') {
 //            return;
 //        }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -14,7 +14,7 @@ use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class ParserTest extends TestCase {
     public function testIf() {
-        $tpl = '<p bi-if="empty(items)">There are no items!!!</p>';
+        $tpl = '<p x-if="empty(items)">There are no items!!!</p>';
 
         $compiler = new Compiler();
         $compiler->defineFunction('empty');
@@ -28,7 +28,7 @@ class ParserTest extends TestCase {
     }
 
     public function testEach() {
-        $tpl = '<ul bi-each="people"><li>Hi {name}!</li></ul>';
+        $tpl = '<ul x-each="people"><li>Hi {name}!</li></ul>';
 
         $compiler = new Compiler();
 
@@ -36,7 +36,7 @@ class ParserTest extends TestCase {
     }
 
     public function testEachAs() {
-        $tpl = '<ul bi-each="comments" bi-as="comment"><li>{name}: {comment.body}</li></ul>';
+        $tpl = '<ul x-each="comments" x-as="comment"><li>{name}: {comment.body}</li></ul>';
 
         $compiler = new Compiler();
 
@@ -44,7 +44,7 @@ class ParserTest extends TestCase {
     }
 
     public function testParsing() {
-        $html = '<foo>{this} is a <a if="{foo + bar}" literal s=\'foo bar\'>foo</a>       1 > 2<br> <Time foo.dateInserted /><each "a + b + c"></each></foo>';
+        $html = '<foo>{this} is a <a x-if="{foo + bar}" literal s=\'foo bar\'>foo</a>       1 > 2<br> <Time foo.dateInserted /><each "a + b + c"></each></foo>';
 
         $parser = xml_parser_create_ns('UTF-8', ':');
 

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -29,7 +29,7 @@ class TemplateTest extends AbstractTest {
     public function testComponentRegister() {
         $data = ['dateInserted' => '2001-01-01'];
 
-        $rendered = $this->renderFixture('bi-component', $data);
+        $rendered = $this->renderFixture('x-component', $data);
 
         $this->assertEquals('<time datetime="2001-01-01T00:00:00-05:00">2001-01-01T00:00:00-05:00</time>', trim($rendered));
     }

--- a/tests/fixtures/bi-component.html
+++ b/tests/fixtures/bi-component.html
@@ -1,3 +1,0 @@
-<time bi-component="long-date" datetime="{formatDate(date, 'c')}">{formatDate(date, 'r')}</time>
-
-<long-date date="{dateInserted}" />

--- a/tests/fixtures/discussion.html
+++ b/tests/fixtures/discussion.html
@@ -10,7 +10,7 @@
 <p>{body}</p>
 
 <h2>Comments</h2>
-<ul bi-each="comments">
+<ul x-each="comments">
   <li>
     <div>{username}</div>
 

--- a/tests/fixtures/each-as.html
+++ b/tests/fixtures/each-as.html
@@ -1,3 +1,3 @@
-<ul bi-each="comments" bi-as="comment">
+<ul x-each="comments" x-as="comment">
     <li>{name}: {comment.body}</li>
 </ul>

--- a/tests/fixtures/x-component.html
+++ b/tests/fixtures/x-component.html
@@ -1,0 +1,3 @@
+<time x-component="long-date" datetime="{formatDate(date, 'c')}">{formatDate(date, 'r')}</time>
+
+<long-date date="{dateInserted}" />

--- a/tests/specs/01-language.yml
+++ b/tests/specs/01-language.yml
@@ -1,8 +1,8 @@
 overview: Basic tests for template language features.
 tests:
-  - name: bi-if
+  - name: x-if
     template: >
-      <p bi-if="empty(items)">empty</p>
+      <p x-if="empty(items)">empty</p>
     tests:
       - name: no data
         expected: '<p>empty</p>'
@@ -13,10 +13,10 @@ tests:
       - name: has data
         expected: ''
         data: { items: [1] }
-  - name: bi-if else
+  - name: x-if else
     template: |
-      <div bi-if="signedIn">Welcome!</div>
-      <div bi-else>Sign in to participate.</div>
+      <div x-if="signedIn">Welcome!</div>
+      <div x-else>Sign in to participate.</div>
     tests:
       - name: 'true'
         data: { signedIn: true }
@@ -24,9 +24,9 @@ tests:
       - name: 'false'
         data: { signedIn: false }
         expected: '<div>Sign in to participate.</div>'
-  - name: bi-each
+  - name: x-each
     template: |
-      <ul bi-each="people"><li>Hi {name}!</li></ul>
+      <ul x-each="people"><li>Hi {name}!</li></ul>
     tests:
       - name: no data
         data: { }
@@ -37,7 +37,7 @@ tests:
             - { name: you }
             - { name: us }
         expected: '<ul><li>Hi you!</li><li>Hi us!</li></ul>'
-  - name: bi-each bi-as
+  - name: x-each x-as
     data:
       name: 'How'
       comments:
@@ -46,35 +46,35 @@ tests:
     tests:
       - name: item
         template: |
-          <ul bi-each="comments" bi-as="comment"><li>{name}: {comment.body}</li></ul>
+          <ul x-each="comments" x-as="comment"><li>{name}: {comment.body}</li></ul>
         expected: '<ul><li>How: do I?</li><li>How: do you?</li></ul>'
       - name: with index
         template: |
-          <ul bi-each="comments" bi-as="i comment"><li>{i} {name}: {comment.body}</li></ul>
+          <ul x-each="comments" x-as="i comment"><li>{i} {name}: {comment.body}</li></ul>
         expected: '<ul><li>0 How: do I?</li><li>1 How: do you?</li></ul>'
       - name: 'with index & this'
         template: |
-          <ul bi-each="comments" bi-as="i this"><li>{i}: {body}</li></ul>
+          <ul x-each="comments" x-as="i this"><li>{i}: {body}</li></ul>
         expected: '<ul><li>0: do I?</li><li>1: do you?</li></ul>'
-  - name: bi-each bi-empty
+  - name: x-each x-empty
     template: >
-      <ul bi-each="this"><li>{b}</li><li bi-empty>empty</li></ul>
+      <ul x-each="this"><li>{b}</li><li x-empty>empty</li></ul>
     tests:
-      - name: bi-with data
+      - name: x-with data
         data: [ 'a' ]
         expected: '<ul><li>a</li></ul>'
       - name: no data
         data: []
         expected: '<ul><li>empty</li></ul>'
-  - name: bi-with
-    template: '<div bi-with="user">Hi {name}</div>'
+  - name: x-with
+    template: '<div x-with="user">Hi {name}</div>'
     data: { name: parent, user: { name: child } }
     expected: '<div>Hi child</div>'
-  - name: bi-literal
-    template: '<code bi-literal>Hello <b bi-literal>{username}</b> a > b</code>'
+  - name: x-literal
+    template: '<code x-literal>Hello <b x-literal>{username}</b> a > b</code>'
     data: []
-    expected: '<code>Hello <b bi-literal>{username}</b> a &gt; b</code>'
+    expected: '<code>Hello <b x-literal>{username}</b> a &gt; b</code>'
   - name: x
-    template: '<x bi-if="signedIn">Welcome back</x>'
+    template: '<x x-if="signedIn">Welcome back</x>'
     data: {signedIn: true}
     expected: 'Welcome back'

--- a/tests/specs/02-components.yml
+++ b/tests/specs/02-components.yml
@@ -1,43 +1,43 @@
 overview: Basic tests for template language features.
 tests:
-  - name: bi-component
+  - name: x-component
     template: >
-      <div bi-component="foo">Hello {name}!</div><foo name="{foo}" />
+      <div x-component="foo">Hello {name}!</div><foo name="{foo}" />
     expected: <div>Hello Bar!</div>
     data: {foo: 'Bar', name: 'Baz', child: {name: 'Frank'}}
     tests:
-      - name: default bi-with
-        template: <div bi-component="foo">Hello {name}!</div><foo />
+      - name: default x-with
+        template: <div x-component="foo">Hello {name}!</div><foo />
         expected: <div>Hello Baz!</div>
-      - name: bi-with
-        template: <div bi-component="foo">Hello {name}!</div><foo bi-with="child" />
+      - name: x-with
+        template: <div x-component="foo">Hello {name}!</div><foo x-with="child" />
         expected: <div>Hello Frank!</div>
-      - name: overridden bi-with
+      - name: overridden x-with
         template: >
-          <div bi-component="foo">Hello {name}{punc ?: "!"}</div><foo bi-with="child" punc="?" />
+          <div x-component="foo">Hello {name}{punc ?: "!"}</div><foo x-with="child" punc="?" />
         expected: <div>Hello Frank?</div>
-      - name: bi-include
+      - name: x-include
         template: >
-          <div bi-component="bar">Hello {name}!</div><x bi-include="foo" name="{foo}" />
-  - name: bi-children
+          <div x-component="bar">Hello {name}!</div><x x-include="foo" name="{foo}" />
+  - name: x-children
     template: >
-      <div bi-component="page"><h1 bi-children/></div><page>Hello {name}!</page>
+      <div x-component="page"><h1 x-children/></div><page>Hello {name}!</page>
     data: {name: 'Sam'}
     expected: <div><h1>Hello Sam!</h1></div>
     tests:
       - name: named child
         template: >
-          <page><x bi-block="greet">Hello {name}!</x></page><div bi-component="page"><h1 bi-children="greet" /></div>
-  - name: bi-children nested
+          <page><x x-block="greet">Hello {name}!</x></page><div x-component="page"><h1 x-children="greet" /></div>
+  - name: x-children nested
     data: [{name: 'Frank'}, {name: 'Joe'}]
     template: >-
-      <li bi-component="row" id="{id}"><x bi-children /></li><ul bi-each="this" bi-as="i j"><row id="{i}">{j.name}</row></ul>
+      <li x-component="row" id="{id}"><x x-children /></li><ul x-each="this" x-as="i j"><row id="{i}">{j.name}</row></ul>
     expected: >-
       <ul><li id="0">Frank</li><li id="1">Joe</li></ul>
   - name: unicode
     data: []
     template: >-
-      <span bi-component="flyout-arrow" class="flyout-arrow">▾</span><flyout-arrow />
+      <span x-component="flyout-arrow" class="flyout-arrow">▾</span><flyout-arrow />
     expected: >-
       <span class="flyout-arrow">▾</span>
 


### PR DESCRIPTION
The letter "X" was chosen to mean "extended attribute" and was inspired
by the same prefix in HTTP headers.