### PR TITLE
Caching bug fixes

### DIFF
--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -44,4 +44,37 @@ class RuntimeTest extends AbstractTest {
 
         $ebi->call('missing', 'foo');
     }
+
+    /**
+     * A missing component should not be cached.
+     */
+    public function testCacheMissingComponent() {
+        $ebi = new TestEbi($this);
+
+        $component = 'fooz';
+        $cacheKey = $ebi->getTemplateLoader()->cacheKey($component);
+        $cachePath = $ebi->getCachePath()."/$cacheKey.php";
+
+        $this->assertFileNotExists($cachePath);
+
+        $ebi->lookup($component);
+
+        $this->assertFileNotExists($cachePath);
+    }
+
+    /**
+     * A defined component should be returned when looked up with any namespace.
+     */
+    public function testComponentNamespaceStripping() {
+        $ebi = new TestEbi($this);
+
+        $fn = function ($props, $children = []) {
+
+        };
+
+        $ebi->defineComponent('foo', $fn);
+
+        $component = $ebi->lookup('bar:foo');
+        $this->assertSame($fn, $component);
+    }
 }

--- a/tests/TestEbi.php
+++ b/tests/TestEbi.php
@@ -17,4 +17,8 @@ class TestEbi extends Ebi {
         $cachePath = __DIR__.'/cache/'.trim(strrchr(is_object($class) ? get_class($class) : $class, '\\'), '\\');
         parent::__construct($this->loader, $cachePath);
     }
+
+    public function getCachePath() {
+        return $this->cachePath;
+    }
 }

--- a/tests/TestTemplateLoader.php
+++ b/tests/TestTemplateLoader.php
@@ -23,7 +23,7 @@ class TestTemplateLoader implements TemplateLoaderInterface {
      * @return string Returns the unique key of the component.
      */
     public function cacheKey($component) {
-        return $component;
+        return isset($this->templates[$component]) ? $component : null;
     }
 
     /**


### PR DESCRIPTION
- Don’t compile missing components to the cache folder.
- Properly strip namespaces from components during storage and
definition.
- Add a compile method to allow consumers to ad-hock compile templates.