### PR TITLE
Switch the <x-expr> to the <script> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,41 +306,41 @@ echo '<h'.$props['level'].'>',
 
 Most of Ebi's functionality uses special attributes. However, there are a couple of special tags supported.
 
-### The `<x-expr>` Tag
+### The `<script type="ebi">` Tag
 
-Usually, you write expressions by enclosing them in braces (`{..}`). However, braces don't themselves allow brace characters. They also don't allow multi-line expressions. When you have such an expression you can instead enclose it in an `x-expr` tag.
+Usually, you write expressions by enclosing them in braces (`{..}`). However, braces don't themselves allow brace characters. They also don't allow multi-line expressions. When you have such an expression you can instead enclose it in a `<script tpye="ebi">` tag.
 
 ```html
-<x-expr>
+<script type="ebi">
   join(
     "|",
     [1, 2, 3]
   )
-</x-expr>
+</script>
 ```
 
 ```php
 echo $this->escape(join('|', [1, 2, 3]);
 ```
 
-#### `<x-expr x-unescape>`
+#### `<script x-unescape>`
 
-If you don't want to escape the output in an `<x-expr>` tag then add the `x-unescape` attribute.
+If you don't want to escape the output in an `<script>` tag then add the `x-unescape` attribute. You don't have to include the `type="ebi"` in this case.
 
 ```html
-<x-expr x-unescape>join('>', [1, 2, 3])</x-expr>
+<script x-unescape>join('>', [1, 2, 3])</script>
 ```
 
 ```php
 echo join('>', [1, 2, 3]);
 ```
 
-#### `<x-expr x-as="...">`
+#### `<script x-as="...">`
 
-You can also use the `<x-expr>` tag with an `x-as` attribute to create an expression variable that can be used later in the template.
+You can also use the `<script>` tag with an `x-as` attribute to create an expression variable that can be used later in the template. You don't have to include the `type="ebi"` in this case.
 
 ```html
-<x-expr x-as="title">trim(ucfirst(sentence))</x-expr>
+<script x-as="title">trim(ucfirst(sentence))</script>
 <h1 x-if="!empty(title)">{title}</h1>
 ```
 

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -24,7 +24,7 @@ class Compiler {
     const T_EMPTY = 'x-empty';
     const T_X = 'x';
     const T_INCLUDE = 'x-include';
-    const T_EXPR = 'x-expr';
+    const T_EBI = 'ebi';
     const T_UNESCAPE = 'x-unescape';
     const T_TAG = 'x-tag';
 
@@ -466,12 +466,12 @@ class Compiler {
     protected function compileElementNode(DOMElement $node, CompilerBuffer $out) {
         list($attributes, $special) = $this->splitAttributes($node);
 
-        if ($node->tagName === self::T_EXPR) {
+        if ($node->tagName === 'script' && ((isset($attributes['type']) && $attributes['type']->value === self::T_EBI) || !empty($special[self::T_AS]) || !empty($special[self::T_UNESCAPE]))) {
             $this->compileExpressionNode($node, $attributes, $special, $out);
         } elseif (!empty($special) || $this->isComponent($node->tagName)) {
             $this->compileSpecialNode($node, $attributes, $special, $out);
         } else {
-            $this->compileOpenTag($node, $node->attributes, $special, $out);
+            $this->compileOpenTag($node, $attributes, $special, $out);
 
             foreach ($node->childNodes as $childNode) {
                 $this->compileNode($childNode, $out);
@@ -1094,8 +1094,8 @@ class Compiler {
      * Compile an x-expr node.
      *
      * @param DOMElement $node The node to compile.
-     * @param array $attributes The node's attributes.
-     * @param array $special An array of special attributes.
+     * @param DOMAttr[] $attributes The node's attributes.
+     * @param DOMAttr[] $special An array of special attributes.
      * @param CompilerBuffer $out The compiler output.
      */
     private function compileExpressionNode(DOMElement $node, array $attributes, array $special, CompilerBuffer $out) {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -113,12 +113,12 @@ class ParserTest extends TestCase {
         $ebi = new TestEbi($this);
 
         $src = <<<EOT
-<x-expr>
+<script type="ebi">
     join(
         '|',
         [1, 2, 3]
     )
-</x-expr>
+</script>
 EOT;
 
         $ebi->compile('expr-elem', $src, 'expr-elem');
@@ -131,12 +131,12 @@ EOT;
         $ebi = new TestEbi($this);
 
         $src = <<<EOT
-<x-expr x-as="foo">
+<script x-as="foo">
     {
         a: 1,
         b: 2
     }
-</x-expr>{unescape(json_encode(foo))}{bar}
+</script>{unescape(json_encode(foo))}{bar}
 EOT;
 
         $ebi->defineFunction('json_encode');

--- a/tests/fixtures/breadcrumbs-test.html
+++ b/tests/fixtures/breadcrumbs-test.html
@@ -1,9 +1,9 @@
-<x-expr x-as="breadcrumbsDefault">
+<script x-as="breadcrumbsDefault">
     [
     {url: "#", name: "Breadcrumbs"},
     {url: "#", name: "Breadcrumbs"},
     {url: "#", name: "Breadcrumbs"}
     ]
-</x-expr>
+</script>
 
 <count x-with="breadcrumbs ?: breadcrumbsDefault" />

--- a/tests/specs/01-language.yml
+++ b/tests/specs/01-language.yml
@@ -87,12 +87,12 @@ tests:
       - name: x-literal
         template: '<x x-literal>Hello <b x-literal>{username}</b> a > b</x>'
         expected: 'Hello <b x-literal>{username}</b> a &gt; b'
-  - name: x-expr
-    template: '<x-expr>join(">", [1, 2, 3])</expr>'
+  - name: script
+    template: '<script type="ebi">join(">", [1, 2, 3])</script>'
     expected: '1&gt;2&gt;3'
     tests:
       - name: x-unescaped
-        template: '<x-expr x-unescape>join(">", [1, 2, 3])</expr>'
+        template: '<script x-unescape>join(">", [1, 2, 3])</script>'
         expected: '1>2>3'
       - name: x-as
-        template: '<x-expr x-as="foo">[1, 2, 3]</x-expr>{join(">", foo)}'
+        template: '<script x-as="foo">[1, 2, 3]</script>{join(">", foo)}'


### PR DESCRIPTION
The parser doesn’t like HTML control characters unless they are in a
script tag so we are going to use that for now.