### PR TITLE
Fix bug when reusing cached expressions

### DIFF
--- a/src/ExpressionLanguage.php
+++ b/src/ExpressionLanguage.php
@@ -7,13 +7,14 @@
 
 namespace Ebi;
 
+use Symfony\Component\Cache\Adapter\NullAdapter;
 use Symfony\Component\ExpressionLanguage\Node\ConstantNode;
 use Symfony\Component\ExpressionLanguage\Node\GetAttrNode;
 use Symfony\Component\ExpressionLanguage\Node\NameNode;
 
 class ExpressionLanguage extends \Symfony\Component\ExpressionLanguage\ExpressionLanguage {
     public function __construct() {
-        parent::__construct();
+        parent::__construct(new NullAdapter());
 
         $this->registerNodeFunction(GetAttrNode::class, function (\Symfony\Component\ExpressionLanguage\Compiler $compiler, GetAttrNode $node) {
                 switch ($node->attributes['type']) {

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -68,6 +68,15 @@ abstract class AbstractTest extends TestCase {
         $ebi->defineFunction('concat', function (...$args) {
             return implode('', $args);
         });
+        $ebi->defineFunction('ident', function (...$args) {
+            if (count($args) === 1) {
+                return $args[0];
+            } elseif (empty($args)) {
+                return null;
+            } else {
+                return $args;
+            }
+        });
 
         $rendered = $ebi->render($component, $data);
 

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -222,6 +222,22 @@ EOT;
     }
 
     /**
+     * Test a bug from production that resulted from odd caching behavior.
+     */
+    public function testRepro01() {
+        $r = $this->renderFixture('repro01', ['data' => [1, 2]]);
+
+        $expected = <<<EOT
+{"name":"a","data":[1,2]}
+{"name":"b","data":null}
+
+{"name":"c","data":1}
+EOT;
+
+        $this->assertEquals($expected, $r);
+    }
+
+    /**
      *
      */
 //    public function testVerbTense() {

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -228,10 +228,7 @@ EOT;
         $r = $this->renderFixture('repro01', ['data' => [1, 2]]);
 
         $expected = <<<EOT
-{"name":"a","data":[1,2]}
-{"name":"b","data":null}
-
-{"name":"c","data":1}
+{"name":"a","data":[1,2]}{"name":"b","data":null}{"name":"c","data":1}
 EOT;
 
         $this->assertEquals($expected, $r);

--- a/tests/fixtures/d.html
+++ b/tests/fixtures/d.html
@@ -1,0 +1,1 @@
+{unescape(json_encode(this))}

--- a/tests/fixtures/repro01.html
+++ b/tests/fixtures/repro01.html
@@ -1,0 +1,6 @@
+<x x-if="!mute">
+    <d name="a" data="{data}"/>
+    <d name="b" data="{config}"/>
+    <script x-as="data">data ? data[0] : this</script>
+    <d name="c" data="{data}"/>
+</x>

--- a/tests/fixtures/repro01.html
+++ b/tests/fixtures/repro01.html
@@ -1,6 +1,1 @@
-<x x-if="!mute">
-    <d name="a" data="{data}"/>
-    <d name="b" data="{config}"/>
-    <script x-as="data">data ? data[0] : this</script>
-    <d name="c" data="{data}"/>
-</x>
+<x x-if="!mute"><d name="a" data="{data}"/><d name="b" data="{config}"/><script x-as="data">data ? data[0] : this</script><d name="c" data="{data}"/></x>


### PR DESCRIPTION
The expression language caches compiled expressions, but since the data
that goes into the expressions is contextual then this cache should not
be used.